### PR TITLE
feat: prepare app for zeit deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ passionate developers.
 After cloning the repo:
 
 1. Install dependencies `yarn install`
-2. Run the dev server `yarn start`
+2. Run the dev server `yarn start:dev`
 3. Start building 🚀 
 
 ## Ideas

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "tsc": "tsc",
     "test": "jest",
     "build": "yarn tsc",
-    "start": "set debug=* && ts-node-dev --respawn --transpileOnly ./src/index.ts",
-    "start:prod": "yarn build && env NODE_ENV=production node ./dist",
+    "start": "env NODE_ENV=production node ./dist",
+    "star:dev": "set debug=* && ts-node-dev --respawn --transpileOnly ./src/index.ts",
     "migration:run": "ts-node ./node_modules/typeorm/cli.js migration:run"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,9 @@
   "scripts": {
     "tsc": "tsc",
     "test": "jest",
+    "build": "yarn tsc",
     "start": "set debug=* && ts-node-dev --respawn --transpileOnly ./src/index.ts",
-    "start:prod": "yarn tsc && env NODE_ENV=production node ./dist",
+    "start:prod": "yarn build && env NODE_ENV=production node ./dist",
     "migration:run": "ts-node ./node_modules/typeorm/cli.js migration:run"
   }
 }


### PR DESCRIPTION
**Summary**

I'm planning on deploying this repo to zeit and therefore we need a `build` script in our `package.json` file. I also renamed the current `start` script to `start:dev` so we can use `yarn start` to run the app in production mode