### PR TITLE
Change CreateRoom type

### DIFF
--- a/src/entity/Option.ts
+++ b/src/entity/Option.ts
@@ -3,8 +3,15 @@ import { IsNotEmpty } from 'class-validator';
 
 import { Room } from './Room';
 
+export interface OptionInterface {
+  id: number;
+  label: string;
+  value: string;
+  room: Room;
+}
+
 @Entity()
-export class Option {
+export class Option implements OptionInterface {
   @PrimaryGeneratedColumn()
   id: number;
 
@@ -26,4 +33,11 @@ export class Option {
     { onDelete: 'CASCADE' },
   )
   room: Room;
+
+  static New({ label, value }) {
+    const option: OptionInterface = new Option();
+    option.label = label;
+    option.value = value;
+    return option;
+  }
 }

--- a/src/entity/Room.ts
+++ b/src/entity/Room.ts
@@ -3,8 +3,14 @@ import { IsNotEmpty, ValidateNested } from 'class-validator';
 
 import { Option } from './Option';
 
+export interface RoomInterface {
+  name: string;
+  description?: string;
+  options: Option[];
+}
+
 @Entity()
-export class Room {
+export class Room implements RoomInterface {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/routes/strings.ts
+++ b/src/routes/strings.ts
@@ -1,0 +1,10 @@
+export const ERROR_ROOM_GET_BY_ID = 'ROOM_GET_BY_ID';
+export const ERROR_ROOM_CREATE_EMPTY_DATA = 'ROOM_CREATE_EMPTY_DATA';
+export const ERROR_ROOM_CREATE_EMPTY_OPTIONS = 'ROOM_CREATE_EMPTY_OPTIONS';
+export const ERROR_ROOM_CREATE_VALIDATION = 'ROOM_CREATE_VALIDATION';
+
+export const ERROR_ROOM_GET_BY_ID_MESSAGE = 'Room does not exists';
+export const ERROR_ROOM_CREATE_EMPTY_DATA_MESSAGE =
+  'Empty body sent in when creating a room';
+export const ERROR_ROOM_CREATE_EMPTY_OPTIONS_MESSAGE =
+  'Options cannot be empty';

--- a/src/validation/rooms.ts
+++ b/src/validation/rooms.ts
@@ -1,0 +1,40 @@
+import { RoomInterface } from '../entity/Room';
+import {
+  ERROR_ROOM_CREATE_EMPTY_DATA,
+  ERROR_ROOM_CREATE_EMPTY_OPTIONS,
+  ERROR_ROOM_CREATE_EMPTY_DATA_MESSAGE,
+  ERROR_ROOM_CREATE_EMPTY_OPTIONS_MESSAGE,
+} from '../routes/strings';
+
+export enum ValidationRoomStatus {
+  OK,
+  INVALID,
+}
+
+export interface RoomValidationResult {
+  error?: string;
+  message?: string;
+  status: ValidationRoomStatus;
+}
+
+export function validateRoom(newRoom: RoomInterface): RoomValidationResult {
+  if (newRoom == null) {
+    return {
+      status: ValidationRoomStatus.INVALID,
+      error: ERROR_ROOM_CREATE_EMPTY_DATA,
+      message: ERROR_ROOM_CREATE_EMPTY_DATA_MESSAGE,
+    };
+  }
+
+  const { options = [] } = newRoom;
+
+  if (options == null || options.length < 1) {
+    return {
+      status: ValidationRoomStatus.INVALID,
+      error: ERROR_ROOM_CREATE_EMPTY_OPTIONS,
+      message: ERROR_ROOM_CREATE_EMPTY_OPTIONS_MESSAGE,
+    };
+  }
+
+  return { status: ValidationRoomStatus.OK };
+}


### PR DESCRIPTION
## Summary
This change removes the CreateRoom type and make use of "model level" interfaces to add consistentency (at least statically) between the request body and business logic primitives.

This change also abstracts away the room validation to make room creation more declarative.

## Testing
No unit tests were added, this change was tested functionally though, and everything seems to be working well.  

SS of the API returning OK with expected response:   

<img width="687" alt="Screen Shot 2019-11-19 at 11 24 44 PM" src="https://user-images.githubusercontent.com/545850/69217606-ead7e600-0b23-11ea-9e8a-8c9af13c09b0.png">
